### PR TITLE
cleaning game Name and maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The development journey from a core engine to an ARPG-ready platform.
 ### ⚙️ Execution
 1.  **Clone the Repo:**
     ```bash
-    git clone https://github.com/your-username/SimpleTetris.git
+    git clone https://github.com/your-username/JavaSwingTetris.git
     ```
 2.  **Build with Maven:**
     ```bash
@@ -100,7 +100,7 @@ The development journey from a core engine to an ARPG-ready platform.
     ```
 3.  **Run the JAR:**
     ```bash
-    java -jar target/SimpleTetris-0.9.jar
+    java -jar target/TetrisEngine.jar
     ```
     *Alternatively, run `org.sehes.tetris.Main` directly from your IDE.*
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.sehes</groupId>
-    <artifactId>SwingTetris</artifactId>
+    <artifactId>TetrisEngine</artifactId>
     <version>0.11</version>
     <packaging>jar</packaging>
 
@@ -73,6 +73,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.5.0</version>
                 <configuration>
+                    <finalName>${project.artifactId}</finalName>
                     <archive>
                         <manifest>
                             <mainClass>org.sehes.tetris.Main</mainClass>


### PR DESCRIPTION
## Summary by Sourcery

Update project naming and Maven artifact configuration to align the README usage instructions with the built JAR output.

Build:
- Rename Maven artifactId to TetrisEngine and configure the jar plugin to use the artifactId as the final JAR name.

Documentation:
- Adjust README clone URL and run command to reference the new repository name and JAR filename.